### PR TITLE
use white as the background

### DIFF
--- a/themes/OneLight.tmTheme
+++ b/themes/OneLight.tmTheme
@@ -12,7 +12,7 @@
         <key>settings</key>
         <dict>
           <key>background</key>
-          <string>#FAFAFA</string>
+          <string>#FFFFFF</string>
           <key>foreground</key>
           <string>#383A42</string>
           <key>caret</key>


### PR DESCRIPTION
I use Atom with the [Apex UI Slim Theme](https://github.com/apex/apex-ui-slim) which has a white background, which I much prefer over the `FAFAFA` background colour - perhaps you and the other users may do too. If I want a darker white, as FAFAFA is, then I'll just turn my screen brightness down.

Here is a screenshot of it in Atom with the Apex UI Slim theme:

![screen shot 2017-03-03 at 12 02 31 pm](https://cloud.githubusercontent.com/assets/61148/23537771/4ec2618c-0009-11e7-90d0-66d02528ffe6.png)

And here it is in Visual Studio Code:

![screen shot 2017-03-03 at 12 02 04 pm](https://cloud.githubusercontent.com/assets/61148/23537760/40517f34-0009-11e7-850f-495ea73a5577.png)

Here is the old theme for comparison:

![screen shot 2017-03-03 at 12 04 06 pm](https://cloud.githubusercontent.com/assets/61148/23537803/861bfa30-0009-11e7-9c65-83226ee8651f.png)
